### PR TITLE
Add middleware with arbitrary transducer

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -113,8 +113,8 @@
   (log/info "got" (count records))
   (with-open [w (io/writer file :append true)]
     (.write w (reduce
-               (fn [acc {:keys [key value]}]
-                 (str acc key ":" value "\n"))
+               (fn [acc val]
+                 (str acc val "\n"))
                ""
                records))))
 
@@ -123,7 +123,8 @@
       (flush/flush)
       (flush/timed 1000)
       (flush/max-records 10)
-      (flush/accumulate)))
+      (flush/accumulate)
+      (flush/transform (map :value))))
 
 (defn dev-system
   "Constructs a system map suitable for interactive development."

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -121,10 +121,13 @@
 (def processor
   (-> batch-writer
       (flush/flush)
+      (flush/seen 5)
       (flush/timed 1000)
       (flush/max-records 10)
       (flush/accumulate)
-      (flush/transform (map :value))))
+      (flush/transform (comp
+                        (filter (constantly false))
+                        (map :value)))))
 
 (defn dev-system
   "Constructs a system map suitable for interactive development."

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -6,28 +6,61 @@
   (:require [clj-time.core :as t]
             [taoensso.timbre :as log]))
 
+(def stack
+  (comp (partial take 10) conj))
+
 (defn accumulate
   "Accumulate records into state, and increments a count."
-  [processor]
-  (fn 
-    [deps state records commit]
-    (processor
-     deps
-     (-> (update state :records concat records)
-         (update :count (fnil + 0) (count records)))
-     []
-     commit)))
+  ([processor]
+   (fn 
+     [deps state records commit]
+     (processor
+      deps
+      (-> (update state :records concat records)
+          (update :count (fnil + 0) (count records)))
+      []
+      commit)))
+  ([processor xform]
+   (fn 
+     [deps state records commit]
+     (processor
+      deps
+      (-> (update state :records concat records)
+          (update :count (fnil + 0) (count records)))
+      []
+      commit))))
 
 (defn transform
-  "Applies a transducer to the records batch. Use before accumulate."
+  "Applies a transducer to the records batch. Updates `:seen` key in state, 
+  adding the number of records processed.
+
+  Use before accumulate for filtering or other preprocessing."
   [processor xform]
   (fn
     [deps state records commit]
     (processor
      deps
-     state
+     (update state :seen (fnil + 0) (count records))
      (sequence xform records)
      commit)))
+
+(defn seen
+  "Identifies a maximum seen count as a flush condition. Useful when a filtering
+  transducer has been applied.
+
+  `:count` must be zero, and `:seen` > `n`"
+  [processor n]
+  (fn 
+    [deps state records commit]
+    (let [cnt (count (:records state))]
+      (log/info :seen state)
+      (processor
+       deps
+       (cond-> state
+         (and (= cnt 0)
+              (>= (:seen state) n)) (update :flush? stack (str ":seen > " n)))
+       records
+       commit))))
 
 (defn max-records
   "Identifies a maximum record count flush condition."
@@ -38,12 +71,13 @@
       (processor
        deps
        (cond-> state
-         (>= cnt n) (update :flush? conj (str "Count > " n)))
+         (>= cnt n) (update :flush? stack (str "Count > " n)))
        records
        commit))))
 
 (defn timed
-  "Identifies buffer age as a condition for flushing."
+  "Identifies buffer age as a condition for flushing. The timer starts when
+  state has at least one record."
   [processor ms]
   (fn 
     [deps state records commit]
@@ -57,7 +91,7 @@
          records? (update :epoch #(or % (t/now)))
          (and records?
               elapsed
-              (>= elapsed ms)) (update :flush? conj (str elapsed "ms elapsed.")))
+              (>= elapsed ms)) (update :flush? stack (str elapsed "ms elapsed.")))
        records
        commit))))
 
@@ -68,7 +102,7 @@
     [deps state records commit]
     (let [reason (-> state :flush? seq)
           records (-> state :records seq)]
-      (if (and reason records)
+      (if reason
         (do
           (log/info "Flushing" :reason reason)
           (try 

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -53,7 +53,6 @@
   (fn 
     [deps state records commit]
     (let [cnt (count (:records state))]
-      (log/info :seen state)
       (processor
        deps
        (cond-> state

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -19,9 +19,15 @@
      commit)))
 
 (defn transform
+  "Applies a transducer to the records batch. Use before accumulate."
   [processor xform]
   (fn
-    [deps state records commit]))
+    [deps state records commit]
+    (processor
+     deps
+     state
+     (sequence xform records)
+     commit)))
 
 (defn max-records
   "Identifies a maximum record count flush condition."

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -6,7 +6,7 @@
   (:require [clj-time.core :as t]
             [taoensso.timbre :as log]))
 
-(def stack
+(def ^:private stack
   (comp (partial take 10) conj))
 
 (defn accumulate

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -10,69 +10,66 @@
   "Accumulate records into state, and increments a count."
   [processor]
   (fn 
-    ([state records commit]
-     (accumulate {} state records commit))
-    ([deps state records commit]
-     (processor
-      deps
-      (-> (update state :records concat records)
-          (update :count (fnil + 0) (count records)))
-      []
-      commit))))
+    [deps state records commit]
+    (processor
+     deps
+     (-> (update state :records concat records)
+         (update :count (fnil + 0) (count records)))
+     []
+     commit)))
+
+(defn transform
+  [processor xform]
+  (fn
+    [deps state records commit]))
 
 (defn max-records
   "Identifies a maximum record count flush condition."
   [processor n]
   (fn 
-    ([state records commit]
-     (max-records {} state records commit))
-    ([deps state records commit]
-     (let [cnt (count (:records state))]
-       (processor
-        deps
-        (cond-> state
-          (>= cnt n) (update :flush? conj (str "Count > " n)))
-        records
-        commit)))))
+    [deps state records commit]
+    (let [cnt (count (:records state))]
+      (processor
+       deps
+       (cond-> state
+         (>= cnt n) (update :flush? conj (str "Count > " n)))
+       records
+       commit))))
 
 (defn timed
   "Identifies buffer age as a condition for flushing."
   [processor ms]
   (fn 
-    ([state records commit]
-     (timed {} state records commit))
-    ([deps state records commit]
-     (let [elapsed (some-> (:epoch state)
-                           (t/interval (t/now))
-                           (t/in-millis))
-           records? (> (:count state) 0)]
-       (processor
-        deps
-        (cond-> state
-          records? (update :epoch #(or % (t/now)))
-          (and records?
-               elapsed
-               (>= elapsed ms)) (update :flush? conj (str elapsed "ms elapsed.")))
-        records
-        commit)))))
+    [deps state records commit]
+    (let [elapsed (some-> (:epoch state)
+                          (t/interval (t/now))
+                          (t/in-millis))
+          records? (> (:count state) 0)]
+      (processor
+       deps
+       (cond-> state
+         records? (update :epoch #(or % (t/now)))
+         (and records?
+              elapsed
+              (>= elapsed ms)) (update :flush? conj (str elapsed "ms elapsed.")))
+       records
+       commit))))
 
 (defn flush
-  "Wrap the flush fn."
+  "Wrap the flush fn, which must be 2-arity - [deps records]"
   [flush-fn]
   (fn 
-    ([state records commit]
-     (flush {} state records commit))
-    ([deps state records commit]
-     (let [reason (-> state :flush? seq)
-           records (-> state :records seq)]
-       (if (and reason records)
-         (do
-           (log/info "Flushing" :reason reason)
-           (try 
-             (flush-fn deps records)
-             (commit)
-             {}
-             (catch Exception ex
-               (log/error ex "Failed to flush records")
-               state)))
-         state)))))
+    [deps state records commit]
+    (let [reason (-> state :flush? seq)
+          records (-> state :records seq)]
+      (if (and reason records)
+        (do
+          (log/info "Flushing" :reason reason)
+          (try 
+            (flush-fn deps records)
+            (commit)
+            {}
+            (catch Exception ex
+              (log/error ex "Failed to flush records")
+              state)))
+        state))))

--- a/src/org/purefn/river/flush.clj
+++ b/src/org/purefn/river/flush.clj
@@ -11,24 +11,15 @@
 
 (defn accumulate
   "Accumulate records into state, and increments a count."
-  ([processor]
-   (fn 
-     [deps state records commit]
-     (processor
-      deps
-      (-> (update state :records concat records)
-          (update :count (fnil + 0) (count records)))
-      []
-      commit)))
-  ([processor xform]
-   (fn 
-     [deps state records commit]
-     (processor
-      deps
-      (-> (update state :records concat records)
-          (update :count (fnil + 0) (count records)))
-      []
-      commit))))
+  [processor]
+  (fn 
+    [deps state records commit]
+    (processor
+     deps
+     (-> (update state :records concat records)
+         (update :count (fnil + 0) (count records)))
+     []
+     commit)))
 
 (defn transform
   "Applies a transducer to the records batch. Updates `:seen` key in state, 


### PR DESCRIPTION
Adds a middleware function with arbitrary transducer passed in, and a `:seen` flush condition, triggered after processing (but not accumulating) `n` records - example usage in `dev.clj`.

Some refactoring, remove 3-arity middleware fns.