### PR TITLE
Allow config override

### DIFF
--- a/src/org/purefn/river/batch.clj
+++ b/src/org/purefn/river/batch.clj
@@ -130,7 +130,7 @@
   - `::topics` The topics to consumer from.
 
   - `::bootstrap-servers` hostname:port of a broker in the Kafka cluster to sink from.
-    Prefers the `bootstrap-servers` config item over `bootstrap.servers if both are available.
+    Prefers the `bootstrap-servers` config item over `bootstrap.servers` if both are available.
     Using the `.` version means we cannot override with env vars when needed.`
 
   - `::threads` The number of threads (consumers) to create for each topic. 

--- a/src/org/purefn/river/batch.clj
+++ b/src/org/purefn/river/batch.clj
@@ -130,6 +130,8 @@
   - `::topics` The topics to consumer from.
 
   - `::bootstrap-servers` hostname:port of a broker in the Kafka cluster to sink from.
+    Prefers the `bootstrap-servers` config item over `bootstrap.servers if both are available.
+    Using the `.` version means we cannot override with env vars when needed.`
 
   - `::threads` The number of threads (consumers) to create for each topic. 
   (default 4)
@@ -140,7 +142,8 @@
   ([config]
    {::threads 4
     ::timeout 10000
-    ::bootstrap-servers (get-in config ["kafka" "bootstrap.servers"])}))
+    ::bootstrap-servers (or (get-in config ["kafka" "bootstrap-servers"])
+                            (get-in config ["kafka" "bootstrap.servers"]))}))
 
 (defn batch-consumer
   "Constructor, takes a config and a 2 arg process-fn.


### PR DESCRIPTION
Don't love how this is digging into our config map for the specific things it wants, but this is mainly just to give us an easier path to override configs for local testing. There isn't a way to make a environment variable that will properly override the config name with a `.` in it, so it will prefer a `-` instead. 